### PR TITLE
Added Tagging to Preps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'faker'
 gem 'cloudinary'
 gem 'carrierwave', '~> 1.2'
 
+gem 'acts-as-taggable-on', '~> 6.0'
+
+
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (6.0.0)
+      activerecord (~> 5.0)
     arel (9.0.0)
     autoprefixer-rails (9.1.0)
       execjs
@@ -229,6 +231,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 6.0)
   autoprefixer-rails
   bootsnap
   bootstrap-sass (~> 3.3)

--- a/app/controllers/preps_controller.rb
+++ b/app/controllers/preps_controller.rb
@@ -6,9 +6,15 @@ class PrepsController < ApplicationController
   end
 
   def show
+    @related_preps = @prep.find_related_tags
   end
 
   def new
+    @most_used_tags = []
+    ActsAsTaggableOn::Tag.most_used(5).each do |tag|
+      @most_used_tags << tag.name
+    end
+    @most_used_tags
     @prep = Prep.new
     authorize @prep
   end
@@ -17,6 +23,8 @@ class PrepsController < ApplicationController
     @prep = Prep.new(prep_params)
     @prep.user = current_user
     authorize @prep
+    ActsAsTaggableOn.force_lowercase = true
+    ActsAsTaggableOn.delimiter = ','
     @prep.save
     redirect_to prep_path(@prep)
   end
@@ -36,6 +44,15 @@ class PrepsController < ApplicationController
     redirect_to preps_path
   end
 
+  def tagged
+    if params[:tag].present?
+      @preps = Prep.tagged_with(params[:tag])
+    else
+      @preps = Prep.all
+    end
+    authorize @preps
+  end
+
   private
 
   def set_prep
@@ -44,6 +61,6 @@ class PrepsController < ApplicationController
   end
 
   def prep_params
-    params.require(:prep).permit(:name, :description, :max_participants, :meal, :time, :location, :photo)
+    params.require(:prep).permit(:name, :description, :max_participants, :meal, :time, :location, :photo, :tag_list)
   end
 end

--- a/app/models/prep.rb
+++ b/app/models/prep.rb
@@ -3,6 +3,8 @@ class Prep < ApplicationRecord
   has_many :bookings
   has_many :reviews
 
+  acts_as_taggable_on :tags
+
   mount_uploader :photo, PhotoUploader
 
   validates :name, presence: true
@@ -25,5 +27,13 @@ class Prep < ApplicationRecord
 
   def check_event_time?
     self.time < Time.now
+  end
+
+  def most_used_tags
+    most_used_tags = []
+    ActsAsTaggableOn::Tag.most_used(3).each do |tag|
+      most_used_tags << tag.name
+    end
+    most_used_tags
   end
 end

--- a/app/policies/prep_policy.rb
+++ b/app/policies/prep_policy.rb
@@ -19,4 +19,8 @@ class PrepPolicy < ApplicationPolicy
   def destroy?
     record.user == user
   end
+
+  def tagged?
+    true
+  end
 end

--- a/app/views/preps/index.html.erb
+++ b/app/views/preps/index.html.erb
@@ -37,6 +37,10 @@
       <p><%= prep.meal %></p>
       <p><%= prep.time %></p>
       <p><%= prep.location %></p>
+      <p><% prep.tag_list.each do |tag| %>
+          <%= link_to tag, tagged_path(tag: tag) %>
+        <% end %>
+      </p>
     </li>
   </ul>
 <% end %>

--- a/app/views/preps/new.html.erb
+++ b/app/views/preps/new.html.erb
@@ -3,6 +3,7 @@
 <%= simple_form_for (@prep) do |f| %>
   <%= f.input :name, placeholder: "Henry McLover" %>
   <%= f.input :description, placeholder: "Talk a bit about your event..."%>
+  <%= f.input :tag_list, hint: "People are using these tags most: (#{@most_used_tags.join(", ")})" %>
   <%= f.input :max_participants, placeholder: "1 - 20" %>
   <%= f.input :time %>
   <%= f.input :location, placeholder: "158 Julu Road, Shanghai" %>

--- a/app/views/preps/show.html.erb
+++ b/app/views/preps/show.html.erb
@@ -7,6 +7,10 @@
 <p>Max # of Participants: <%= @prep.max_participants %></p>
 <p><%= @prep.time %></p>
 <p><%= @prep.location %></p>
+<p><% @prep.tag_list.each do |tag| %>
+    <%= link_to tag, tagged_path(tag: tag) %>
+  <% end %>
+</p>
 <p><strong>Bookings:</strong></p>
 <ul>
   <% @prep.bookings.each do |booking| %>

--- a/app/views/preps/tagged.html.erb
+++ b/app/views/preps/tagged.html.erb
@@ -1,0 +1,9 @@
+<h1><%= params[:tag] %></h1>
+<ul>
+  <% @preps.each do |prep| %>
+    <li>
+      <%= link_to prep.name, prep_path(prep) %>
+    </li>
+  <% end %>
+</ul>
+<%= link_to "Back to Events Page", preps_path  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 
   devise_for :users
   root to: 'pages#home'
+  get '/tagged', to: "preps#tagged", as: :tagged
 
   resources :users, only: [:show]
   resources :preps do

--- a/db/migrate/20180808031741_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180808031741_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,36 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20180808031742_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180808031742_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20180808031743_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180808031743_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20180808031744_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180808031744_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20180808031745_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180808031745_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20180808031746_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20180808031746_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
+
+    unless index_exists? :taggings, [:tagger_id, :tagger_type]
+      add_index :taggings, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_07_092330) do
+ActiveRecord::Schema.define(version: 2018_08_08_031746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,31 @@ ActiveRecord::Schema.define(version: 2018_08_07_092330) do
     t.bigint "prep_id"
     t.index ["prep_id"], name: "index_reviews_on_prep_id"
     t.index ["user_id"], name: "index_reviews_on_user_id"
+  end
+
+  create_table "taggings", id: :serial, force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,8 +12,11 @@
 Prep.destroy_all
 puts "Deleted all prior preps"
 
-max_participants = (1..20).to_a
+User.destroy_all
+puts "Deleted all prior users"
 
+max_participants = (1..20).to_a
+tags = ["healthy", "vegan", "vegetarian", "meat", "protein", "high-calorie"]
 
 10.times do
   @prep = Prep.new(
@@ -32,6 +35,7 @@ max_participants = (1..20).to_a
     gender: Faker::Gender.binary_type,
     location: Faker::Address.city,
   )
+  @prep.tag_list.add(tags.sample(3))
   @prep.save
 end
 


### PR DESCRIPTION
Added tags to the preps. 
Tags are now visible on the index and show pages of Prep. 
Tags are now clickable and related events can be found through tags. 
Also, suggestions of which tags to use are also present on the Prep create page. 
Updated the db:seed to include tags.
** Run bundle install, db:migrate, and db:seed